### PR TITLE
Fix #182 Typo in Derive Object error and success messages

### DIFF
--- a/src/components/API/DeriveDraftObject.js
+++ b/src/components/API/DeriveDraftObject.js
@@ -47,16 +47,16 @@ export default function DeriveDraftObject(saveDraftTo, prefix) {
           .then((data) => {
             console.log('data', data[0].object_id);
             const objectId = data[0].object_id;
-            alert(`Derrive Draft Success! Save the following object ID to access later  ${data[0].object_id}`);
+            alert(`Derive Draft Success! Save the following object ID to access later  ${data[0].object_id}`);
             const processed = objectId.replace('://', '/');
-            console.log('derrive 42', `${window.location.origin}/builder/${processed}`);
+            console.log('derive 42', `${window.location.origin}/builder/${processed}`);
             window.location.href = `${window.location.origin}/builder/${processed}`;
           });
       }
     })
     .catch((error) => {
       console.log(`error: ${error}`);
-      alert(`Derrive Draft FAILED! ${error}`);
+      alert(`Derive Draft FAILED! ${error}`);
     });
 }
 


### PR DESCRIPTION
Fixing issue #182 Typos in Derive Object error and success messages. 

 Changes to be committed:
	modified:   src/components/API/DeriveDraftObject.js