### PR TITLE
Fixing Broken Hive and Galaxy Project Links

### DIFF
--- a/src/views/home/HomeView/Galaxy.js
+++ b/src/views/home/HomeView/Galaxy.js
@@ -39,21 +39,20 @@ export default function Other() {
 
   return (
     <Card className={classes.linkCard} elevation={0}>
-      <CardActionArea onClick={() => window.open(galaxyLink)}>
         <CardContent>
           <Typography className={classes.title}>
             <img src={hive} height={65} alt="Galaxy logo" />
             <br />
             <img src={aws} height={35} alt="AWS logo" />
           </Typography>
+
           <Typography className={classes.bullet}>
-            Use Galaxy on AWS, the open source, web-based platform for data
-            intensive biomedical research. Assemble your [pipeline](/about) in the
-            workspace, designate the outputs in the module boxes, and record the
-            entire pipeline as a BCO.
+            BioCompute has been merged into the main Galaxy repository. 
+            This BioCompute enabled instance of Galaxy on AWS is therefore no longer operational. 
+            Thank you to those that have participated in its development.
           </Typography>
+
         </CardContent>
-      </CardActionArea>
     </Card>
   );
 }

--- a/src/views/home/HomeView/Hive.js
+++ b/src/views/home/HomeView/Hive.js
@@ -5,11 +5,14 @@ import {
   Card,
   CardActionArea,
   CardContent,
+  colors,
   makeStyles,
   Typography
 } from '@material-ui/core';
 import hive from 'src/images/hive.png';
 import aws from 'src/images/powered-by-aws.png';
+import { red } from '@material-ui/core/colors';
+import { FormatColorText } from '@material-ui/icons';
 
 const useStyles = makeStyles({
   bullet: {
@@ -40,23 +43,30 @@ export default function Hive() {
 
   return (
     <Card className={classes.supportCard} elevation={0}>
-      <CardActionArea onClick={() => window.open(hiveLink)}>
-        <CardContent>
-          <Typography className={classes.title}>
-            <img src={hive} height={65} alt="HIVE logo" />
-            <br />
-            <img src={aws} height={35} alt="AWS logo" />
-          </Typography>
-          <Typography className={classes.bullet}>
-            Access AWS HIVE, the High-Performance Integrated Virtual Environment, on AWS.
-            HIVE is a cloud-based environment optimized for the storage and analysis
-            of extra-large data, such as biomedical data, clinical data,
-            next-generation sequencing (NGS) data, mass spectrometry files, confocal
-            microscopy images, post-market surveillance data, medical recall data,
-            and many others.
-          </Typography>
-        </CardContent>
-      </CardActionArea>
+      <CardContent>
+        <Typography className={classes.title}>
+          <img src={hive} height={65} alt="HIVE logo" />
+          <br />
+          <img src={aws} height={35} alt="AWS logo" />
+        </Typography>
+
+        <html>
+        <body>
+        <p>
+        AWS instance of HIVE is temporarily down. Check back later for access.
+        </p>
+        </body>
+        </html>
+
+        <Typography className={classes.bullet}>
+          Access AWS HIVE, the High-Performance Integrated Virtual Environment, on AWS.
+          HIVE is a cloud-based environment optimized for the storage and analysis
+          of extra-large data, such as biomedical data, clinical data,
+          next-generation sequencing (NGS) data, mass spectrometry files, confocal
+          microscopy images, post-market surveillance data, medical recall data,
+          and many others.
+        </Typography>
+      </CardContent>
     </Card>
   );
 }

--- a/src/views/resources/Resources/Galaxy.js
+++ b/src/views/resources/Resources/Galaxy.js
@@ -43,7 +43,6 @@ export default function Galaxy() {
 
   return (
     <Card className={`${classes.root} ${classes.linkCard}`} elevation={0}>
-      <CardActionArea onClick={() => window.open(galaxyLink)}>
         <CardContent>
           <Typography className={classes.title}>
             <img src={hive} height={65} alt="Galaxy logo" />
@@ -56,7 +55,6 @@ export default function Galaxy() {
             BCO format.
           </Typography>
         </CardContent>
-      </CardActionArea>
     </Card>
   );
 }

--- a/src/views/resources/Resources/Hive.js
+++ b/src/views/resources/Resources/Hive.js
@@ -44,7 +44,6 @@ export default function Hive() {
 
   return (
     <Card className={`${classes.root} ${classes.supportCard}`} elevation={0}>
-      <CardActionArea onClick={() => window.open(hiveLink)}>
         <CardContent>
           <Typography className={classes.title}>
             <img src={hive} height={65} alt="HIVE logo" />
@@ -57,7 +56,6 @@ export default function Hive() {
             from workflows.
           </Typography>
         </CardContent>
-      </CardActionArea>
     </Card>
   );
 }


### PR DESCRIPTION
Fixing #171 

Links to Hive and Galaxy Project were taken down on both Home and Resources pages. 
Descriptions under the logos were modified on the Home page only. 
Let me know if I should change the text on the Resources page or add a link to 
the main Galaxy repository.

 Changes to be committed:
	modified:   src/views/home/HomeView/Galaxy.js
	modified:   src/views/home/HomeView/Hive.js
	modified:   src/views/resources/Resources/Galaxy.js
	modified:   src/views/resources/Resources/Hive.js