### PR TITLE
Update to validation functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",
     "depcheck": "^1.4.2",
+    "file-saver": "^2.0.5",
     "formik": "^2.1.5",
     "moment": "^2.27.0",
     "object-hash": "^2.2.0",

--- a/src/components/API/ApiValidateSchema.js
+++ b/src/components/API/ApiValidateSchema.js
@@ -1,0 +1,53 @@
+// /src/components/Api/ApiValidateSchema.js
+
+/* Validated a BCO using the API */
+
+import PropTypes from 'prop-types';
+import { saveAs } from 'file-saver';
+
+export default function ApiValidateSchema(objectInformation, contents, setPublish, viewResult) {
+  fetch(`${objectInformation.hostname}/api/objects/validate/`, {
+    method: 'POST',
+    body: JSON.stringify({
+      POST_validate_bco: [
+        contents
+      ]
+
+    }),
+    headers: {
+      'Content-type': 'application/json; charset=UTF-8'
+    }
+  })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(response.status);
+      } else {
+        return response.json()
+          .then((data) => {
+            console.log('POST_validate_bco: Success!', data);
+            if (viewResult === 'download') {
+              const blob = new Blob([JSON.stringify(data)], { type: 'text/json' });
+              saveAs(blob, `${objectInformation.object_id}.json`);
+            }
+            if (viewResult === 'display') {
+              const link = document.createElement('a');
+              const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'text/json' });
+              //   alert(`Result display: ${blob}`);
+              link.href = URL.createObjectURL(blob);
+              window.open(link);
+            }
+          });
+      }
+    })
+    .catch((error) => {
+      console.log(`error: ${error}`);
+      alert(`Save Draft FAILED! ${error}`);
+    });
+}
+
+ApiValidateSchema.PropTypes = {
+  objectInformation: PropTypes.object.isRequired,
+  contents: PropTypes.object.isRequired,
+  setPublish: PropTypes.func,
+  viewResult: PropTypes.string,
+};

--- a/src/components/API/CreateDraftObject.js
+++ b/src/components/API/CreateDraftObject.js
@@ -5,7 +5,7 @@ draft id */
 
 export default function CreateDraftObject(saveDraftTo, contents, prefix) {
   const objectContents = contents;
-  console.log('objectContents', contents);
+  const ownerGroup = `${prefix}_drafter`.toLocaleLowerCase();
 
   fetch(`${saveDraftTo[0]}/api/objects/drafts/create/`, {
     method: 'POST',
@@ -15,7 +15,7 @@ export default function CreateDraftObject(saveDraftTo, contents, prefix) {
           contents: objectContents,
           prefix,
           schema: 'IEEE',
-          owner_group: 'bco_drafter'
+          owner_group: ownerGroup
         }
       ]
     }),
@@ -32,10 +32,10 @@ export default function CreateDraftObject(saveDraftTo, contents, prefix) {
         const data = await response.json();
         throw new Error(data[0].message);
       }
-      if (response.status === 200) {
+      if (response.status === 201) {
         const data = await response.json();
         console.log('data', data);
-        const objectId = data[0].object_id;
+        const objectId = data.object_id;
         alert(`Create Draft Success! Save the following object ID to access later  ${objectId}`);
         const processed = objectId.replace('://', '/');
         window.location.href = `${window.location}/${processed}`;

--- a/src/components/PermissionTools.js
+++ b/src/components/PermissionTools.js
@@ -1,7 +1,7 @@
 // src/components/PermissionTools.js
 
 import React, { useEffect, useState, useContext } from 'react';
-import { Grid, TextField } from '@material-ui/core';
+import { Box, Grid, TextField } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import Accordion from '@material-ui/core/Accordion';
 import AccordionSummary from '@material-ui/core/AccordionSummary';
@@ -17,6 +17,7 @@ import ModifyDraftObject from 'src/components/API/ModifyDraftObject';
 import PublishDraftObject from 'src/components/API/PublishDraftObject';
 import DeleteDraftObject from 'src/components/API/DeleteDraftObject';
 import ValidateSchema from 'src/components/ValidateSchema';
+import ApiValidateSchema from 'src/components/API/ApiValidateSchema';
 import ServerList from 'src/utils/ServerList';
 import { FetchContext } from 'src/App';
 
@@ -45,6 +46,8 @@ export default function PermissionTools({
   const [prefix, setPrefix] = useState('BCO');
   const fc = useContext(FetchContext);
   const classes = useStyles();
+  const [viewResult, setViewResult] = useState();
+
   let ApiInfo = JSON.parse(localStorage.getItem('user'));
   if (ApiInfo === null) {
     // Use the anon token, which is publicly available.
@@ -61,8 +64,11 @@ export default function PermissionTools({
       ModifyDraftObject(objectInformation, contents);
     } else if (which === 'createDraft') {
       CreateDraftObject(saveDraftTo, contents, prefix);
-    } else if (which === 'validateDraft') {
-      ValidateSchema(contents, setPublish, publish);
+    } else if (which === 'validateDraft' && newDraft === true) {
+      ValidateSchema(contents, setPublish, viewResult);
+    } else if (which === 'validateDraft' && newDraft !== true) {
+      ApiValidateSchema(objectInformation, contents, setPublish, viewResult);
+      console.log(viewResult, publish);
     } else if (which === 'publishDraft') {
       PublishDraftObject(objectInformation, contents);
     } else if (which === 'downloadDraft') {
@@ -82,7 +88,10 @@ export default function PermissionTools({
     }
   }
 
-  // ----- INITIAL RENDER ----- //
+  function checkResult(checked) {
+    setViewResult(checked.target.value);
+    console.log(checked.target.value);
+  }
 
   return (
     <div className={classes.root}>
@@ -232,13 +241,33 @@ export default function PermissionTools({
                   <Typography>
             &nbsp;
                   </Typography>
+                  <Typography>
+                    <Box>
+                      <input
+                        type="radio"
+                        data-limit="only-one-in-a-group"
+                        name="results"
+                        value="display"
+                        onChange={checkResult}
+                      />
+                    &nbsp;&nbsp;Display Validation&nbsp;&nbsp;
+                      <input
+                        type="radio"
+                        data-limit="only-one-in-a-group"
+                        name="results"
+                        value="download"
+                        onChange={checkResult}
+                      />
+                    &nbsp;&nbsp;Download Validation&nbsp;&nbsp;
+                    </Box>
+                  </Typography>
                   <Button
                     variant="contained"
                     color="primary"
                     disableElevation
-                    // disabled={savePublishTo === ''}
                     fullWidth
                     onClick={() => clickActions('validateDraft')}
+                    disabled={!viewResult}
                   >
                     Validate DRAFT
                   </Button>

--- a/src/components/ValidateSchema.js
+++ b/src/components/ValidateSchema.js
@@ -4,12 +4,15 @@
 
 import Ajv from 'ajv';
 import object from 'src/utils/ieee2791/2791object';
+import PropTypes from 'prop-types';
+import { saveAs } from 'file-saver';
 
 const ajv = Ajv({ allErrors: true });
 
-export default function ValidateSchema(contents, setPublish) {
+export default function ValidateSchema(contents, setPublish, viewResult) {
   const BcoSchema = object;
   console.log('objectContents', contents);
+  const objectId = (contents.object_id ? contents.object_id : 'new_draft');
 
   const valid = ajv.validate(BcoSchema, contents);
   if (valid) {
@@ -19,17 +22,35 @@ export default function ValidateSchema(contents, setPublish) {
     alert('BCO is valid');
   } else {
     console.log('BCO is INVALID!', ajv.errors, contents);
+    if (viewResult === 'download') {
+      const blob = new Blob([JSON.stringify(ajv.errors)], { type: 'text/json' });
+      saveAs(blob, `${objectId}.json`);
+      console.log(`result download: ${viewResult}`);
+    }
+    if (viewResult === 'display') {
+      console.log(`result display: ${viewResult}`);
+      const link = document.createElement('a');
+      const blob = new Blob([JSON.stringify(ajv.errors, null, 2)], { type: 'text/json' });
+      link.href = URL.createObjectURL(blob);
+      window.open(link);
+    }
     // eslint-disable-next-line no-alert
-    alert(`
-      You have an error in your ${ajv.errors[0].keyword}.
-      "${ajv.errors[0].dataPath}"
-      ${ajv.errors[0].message}
+    // alert(`
+    //   You have an error in your ${ajv.errors[0].keyword}.
+    //   "${ajv.errors[0].dataPath}"
+    //   ${ajv.errors[0].message}
 
-      1) If this field is blank, you may need to delete it. Try using the Tree view.
+    //   1) If this field is blank, you may need to delete it. Try using the Tree view.
 
-      2) If this field appears correct, check for extra spaces. 
+    //   2) If this field appears correct, check for extra spaces.
 
-      For more information check the schema here:
-        ${ajv.errors[0].schemaPath}`);
+    //   For more information check the schema here:
+    //     ${ajv.errors[0].schemaPath}`);
   }
 }
+
+ValidateSchema.PropTypes = {
+  contents: PropTypes.object.isRequired,
+  setPublish: PropTypes.func,
+  viewResult: PropTypes.string
+};

--- a/src/views/objects/ObjectsListView/Results.js
+++ b/src/views/objects/ObjectsListView/Results.js
@@ -343,7 +343,7 @@ export default function Results({ rowInfo }) {
           </Table>
         </TableContainer>
         <TablePagination
-          rowsPerPageOptions={[5, 10, 25]}
+          rowsPerPageOptions={[5, 10, 25, 50, 100]}
           component="div"
           count={rows.length}
           rowsPerPage={rowsPerPage}


### PR DESCRIPTION
validate now uses local or remote depending on the stat of the bco.
validation now offers a choice for download or new tab, both showing full list of errors.

Changes to be committed:
	modified:   package.json
	new file:   src/components/API/ApiValidateSchema.js
	modified:   src/components/API/CreateDraftObject.js
	modified:   src/components/PermissionTools.js
	modified:   src/components/ValidateSchema.js
	modified:   src/views/objects/ObjectsListView/Results.js